### PR TITLE
複数の引数を持つ関数を定義できない問題の修正

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -128,6 +128,7 @@ Function *CodeGen::generatePrototype(PrototypeAST *proto, Module *mod){
 	Function::arg_iterator arg_iter=func->arg_begin();
 	for(int i=0; i<proto->getParamNum(); i++){
 		arg_iter->setName(proto->getParamName(i).append("_arg"));
+		++arg_iter;
 	}
 
 	return func;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -188,7 +188,12 @@ PrototypeAST *Parser	::visitPrototype(){
 
 	//parameter_list
 	std::vector<std::string> param_list;
+	bool is_first_param = true;
 	while(true){
+		//','
+		if(!is_first_param && Tokens->getCurType()==TOK_SYMBOL && Tokens->getCurString()==","){
+			Tokens->getNextToken();
+		}
 		if(Tokens->getCurType()==TOK_INT){
 			Tokens->getNextToken();
 		}else{
@@ -208,6 +213,7 @@ PrototypeAST *Parser	::visitPrototype(){
 			Tokens->applyTokenIndex(bkup);
 			return NULL;
 		}
+		is_first_param = false;
 	}
 	
 


### PR DESCRIPTION
はじめまして、ide-anと申します。

現在のmasterの実装では複数の引数を持つ関数を定義するとParse Errorを起こす問題があります。
また、コード生成時においても複数の引数を持つ場合にエラーになることが分かりました。

このpull requestでは以下のの修正を行なっています。
- `parser.cpp`の`visitPrototype()`で引数リストのカンマ区切りを見逃していたのを修正
- `codegen.cpp`の`generatePrototype()`で複数の引数についてそれぞれにアロケートが行われていなかったのを修正
