### PR TITLE
{}をINDENTとDEDENTにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,29 +30,29 @@ FRONT_OBJ = $(MAIN_OBJ) $(LEXER_OBJ) $(AST_OBJ) $(PARSER_OBJ) $(CODEGEN_OBJ)
 
 TOOL = $(BIN_DIR)/dcc
 CONFIG = llvm-config
-LLVM_FLAGS = --cxxflags --ldflags --libs
+LLVM_FLAGS = --cxxflags --ldflags --libs --system-libs
 INC_FLAGS = -I$(INC_DIR)
 
 
-all:$(FRONT_OBJ) 
+all:$(FRONT_OBJ)
 	mkdir -p $(BIN_DIR)
 	$(CC) -g $(FRONT_OBJ) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -ldl -o $(TOOL)
 
 $(MAIN_OBJ):$(MAIN_SRC_PATH)
 	mkdir -p $(OBJ_DIR)
-	$(CC) -g $(MAIN_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(MAIN_OBJ) 
+	$(CC) -g $(MAIN_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(MAIN_OBJ)
 
 $(LEXER_OBJ):$(LEXER_SRC_PATH)
-	$(CC) -g $(LEXER_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(LEXER_OBJ) 
+	$(CC) -g $(LEXER_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(LEXER_OBJ)
 
 $(AST_OBJ):$(AST_SRC_PATH)
-	$(CC) -g $(AST_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(AST_OBJ) 
+	$(CC) -g $(AST_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(AST_OBJ)
 
 $(PARSER_OBJ):$(PARSER_SRC_PATH)
-	$(CC) -g $(PARSER_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(PARSER_OBJ) 
+	$(CC) -g $(PARSER_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(PARSER_OBJ)
 
 $(CODEGEN_OBJ):$(CODEGEN_SRC_PATH)
-	$(CC) -g $(CODEGEN_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(CODEGEN_OBJ) 
+	$(CC) -g $(CODEGEN_SRC_PATH) $(INC_FLAGS) `$(CONFIG) $(LLVM_FLAGS)` -c -o $(CODEGEN_OBJ)
 
 clean:
 	rm -rf $(FRONT_OBJ) $(TOOL)

--- a/inc/codegen.hpp
+++ b/inc/codegen.hpp
@@ -1,4 +1,4 @@
-#ifndef CODEGEN_HPP 
+#ifndef CODEGEN_HPP
 #define CODEGEN_HPP
 
 
@@ -8,18 +8,18 @@
 #include<string>
 #include<vector>
 #include<llvm/ADT/APInt.h>
-#include<llvm/Constants.h>
+#include<llvm/IR/Constants.h>
 #include<llvm/ExecutionEngine/ExecutionEngine.h>
-#include<llvm/ExecutionEngine/JIT.h>
-#include<llvm/Linker.h>
-#include<llvm/LLVMContext.h>
-#include<llvm/Module.h>
-#include<llvm/Metadata.h>
+#include<llvm/ExecutionEngine/MCJIT.h>
+#include<llvm/Linker/Linker.h>
+#include<llvm/IR/LLVMContext.h>
+#include<llvm/IR/Module.h>
+#include<llvm/IR/Metadata.h>
 #include<llvm/Support/Casting.h>
-#include<llvm/IRBuilder.h>
-#include<llvm/Support/IRReader.h>
-#include<llvm/MDBuilder.h>
-#include<llvm/ValueSymbolTable.h>
+#include<llvm/IR/IRBuilder.h>
+#include<llvm/IRReader/IRReader.h>
+#include<llvm/IR/MDBuilder.h>
+#include<llvm/IR/ValueSymbolTable.h>
 #include"APP.hpp"
 #include"AST.hpp"
 //using namespace llvm;

--- a/src/dcc.cpp
+++ b/src/dcc.cpp
@@ -99,7 +99,7 @@ bool OptionParser::parseOption(){
  */
 int main(int argc, char **argv) {
 	llvm::InitializeNativeTarget();
-	llvm::sys::PrintStackTraceOnErrorSignal();
+	llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
 	llvm::PrettyStackTraceProgram X(argc, argv);
 
 	llvm::EnableDebugBuffering = true;
@@ -149,15 +149,15 @@ int main(int argc, char **argv) {
 	}
 
 
-	llvm::PassManager pm;
+	llvm::legacy::PassManager pm;
 
 	//SSA化
 	pm.add(llvm::createPromoteMemoryToRegisterPass());
 
 	//出力
-	std::string error;
-	llvm::raw_fd_ostream raw_stream(opt.getOutputFileName().c_str(), error);
-	pm.add(createPrintModulePass(&raw_stream));
+	std::error_code error;
+	llvm::raw_fd_ostream raw_stream(opt.getOutputFileName().c_str(), error, llvm::sys::fs::F_None);
+	mod.print(raw_stream, nullptr);
 	pm.run(mod);
 	raw_stream.close();
 

--- a/src/dcc.cpp
+++ b/src/dcc.cpp
@@ -1,7 +1,7 @@
-#include "llvm/Assembly/PrintModulePass.h"
-#include "llvm/LLVMContext.h"
-#include "llvm/Module.h"
-#include "llvm/PassManager.h"
+#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/LinkAllPasses.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormattedStream.h"
@@ -83,7 +83,7 @@ bool OptionParser::parseOption(){
 	if (OutputFileName.empty() && (len > 2) &&
 		ifn[len-3] == '.' &&
 		((ifn[len-2] == 'd' && ifn[len-1] == 'c'))) {
-		OutputFileName = std::string(ifn.begin(), ifn.end()-3); 
+		OutputFileName = std::string(ifn.begin(), ifn.end()-3);
 		OutputFileName += ".s";
 	} else if(OutputFileName.empty()){
 		OutputFileName = ifn;
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
 	}
 
 	CodeGen *codegen=new CodeGen();
-	if(!codegen->doCodeGen(tunit, opt.getInputFileName(), 
+	if(!codegen->doCodeGen(tunit, opt.getInputFileName(),
 				opt.getLinkFileName(), opt.getWithJit()) ){
 		fprintf(stderr, "err at codegen\n");
 		SAFE_DELETE(parser);
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
 		exit(1);
 	}
 
-	
+
 	llvm::PassManager pm;
 
 	//SSA化
@@ -164,6 +164,6 @@ int main(int argc, char **argv) {
 	//delete
 	SAFE_DELETE(parser);
 	SAFE_DELETE(codegen);
-  
+
 	return 0;
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -14,6 +14,8 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 	std::string token_str;
 	int line_num=0;
 	bool iscomment=false;
+	int indent=0;//indent level
+	int indent_length=2;
 
 	ifs.open(input_filename.c_str(), std::ios::in);
 	if(!ifs)
@@ -22,33 +24,66 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 		char next_char;
 		std::string line;
 		Token *next_token;
-		int index=0;				
+		int index=0;
 		int length=cur_line.length();
-	
-		while(index<length){	
+		int ishead=true;
+
+		while(index<length){
 			next_char = cur_line.at(index++);
 
 			//コメントアウト読み飛ばし
 			if(iscomment){
-				if( (length-index) < 2 
-					||	(cur_line.at(index) != '*') 
+				if( (length-index) < 2
+					||	(cur_line.at(index) != '*')
 					|| (cur_line.at(index++) != '/') ){
 					continue;
 				}else{
 					iscomment=false;
 				}
 			}
-		
+
 			//EOF
 			if(next_char == EOF){
 				token_str = EOF;
 				next_token = new Token(token_str, TOK_EOF, line_num);
-		
+			//Space or INDENT
 			}else if(isspace(next_char)){
-				continue;
+				if(!ishead)continue;
+					token_str += next_char;
+					while(isspace(cur_line.at(index))){
+						token_str += next_char;
+						next_char = cur_line.at(index++);
+					}
+					if(!indent)indent_length=token_str.size();
+					//インデントが増えていればINDENT,減っていればDEDENT, そのままなら無視
+					if(token_str.size() > indent*indent_length){
+						next_token = new Token("INDENT", TOK_INDENT, line_num);
+						indent++;
+						ishead = false;
+					}else if(indent && token_str.size() < indent*indent_length){
+						printf("%d\n", indent*indent_length);
+						printf("%d\n", token_str.size());
 
-			//IDENTIFIER
-			}else if(isalpha(next_char)){
+						next_token = new Token("DEDENT", TOK_DEDENT, line_num);
+						indent--;
+						ishead = false;
+					}else{
+						ishead = false;
+						token_str.clear();
+						continue;
+					}
+				// Indentレベル１からのDEDENT
+			}else if(!isspace(next_char) && ishead && indent){
+					next_token = new Token("DEDENT", TOK_DEDENT, line_num);
+					indent--;
+					while(indent){
+						tokens->pushToken(next_token);
+						indent--;
+					}
+					ishead=false;
+					index--;//今選択している文字をまきもどし
+				//IDENTIFIER
+				}else if(isalpha(next_char)){
 				token_str += next_char;
 				next_char = cur_line.at(index++);
 				while(isalnum(next_char)){
@@ -58,20 +93,24 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 						break;
 				}
 				index--;
-		
+
 				if(token_str == "int"){
 					next_token = new Token(token_str, TOK_INT, line_num);
+					ishead = false;
 				}else if(token_str == "return"){
 					next_token = new Token(token_str, TOK_RETURN, line_num);
+					ishead = false;
 				}else{
 					next_token = new Token(token_str, TOK_IDENTIFIER, line_num);
+					ishead = false;
 				}
-		
+
 			//数字
 			}else if(isdigit(next_char)){
 				if(next_char=='0'){
 					token_str += next_char;
 					next_token = new Token(token_str, TOK_DIGIT, line_num);
+					ishead = false;
 				}else{
 					token_str += next_char;
 					next_char = cur_line.at(index++);
@@ -80,9 +119,10 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 						next_char = cur_line.at(index++);
 					}
 					next_token = new Token(token_str, TOK_DIGIT, line_num);
+					ishead = false;
 					index--;
 				}
-		
+
 			//コメント or '/'
 			}else if(next_char == '/'){
 				token_str += next_char;
@@ -91,18 +131,19 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 				//コメントの場合
 				if(next_char == '/'){
 						break;
-		
+
 				//コメントの場合
 				}else if(next_char == '*'){
 					iscomment=true;
 					continue;
-		
+
 				//DIVIDER('/')
 				}else{
 					index--;
 					next_token = new Token(token_str, TOK_SYMBOL, line_num);
+					ishead = false;
 				}
-		
+
 			//それ以外(記号)
 			}else{
 				if(next_char == '*' ||
@@ -117,6 +158,7 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 						next_char == '}'){
 					token_str += next_char;
 					next_token = new Token(token_str, TOK_SYMBOL, line_num);
+					ishead = false;
 
 				//解析不能字句
 				}else{
@@ -125,7 +167,7 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 					return NULL;
 				}
 			}
-		
+
 			//Tokensに追加
 			tokens->pushToken(next_token);
 			token_str.clear();
@@ -147,7 +189,7 @@ TokenStream *LexicalAnalysis(std::string input_filename){
 	ifs.close();
 	return tokens;
 }
-	
+
 
 
 /**
@@ -180,7 +222,7 @@ bool TokenStream::getNextToken(){
 		return false;
 	}else if( CurIndex < size ){
 		CurIndex++;
-		return true;	
+		return true;
 	}else{
 		return false;
 	}
@@ -216,3 +258,11 @@ bool TokenStream::printTokens(){
 }
 
 
+int main(int argc, char** argv){
+  std::string inputFile;
+  inputFile=argv[1];
+  TokenStream *Test = LexicalAnalysis(inputFile);
+  Test->printTokens();
+
+  return 0;
+}


### PR DESCRIPTION
- lexerの空白の処理を変更し、INDENT, DEDENTを認識できるようにする。
    - 行ごとに先頭のTokenを認識するフラグを立てる
        - 先頭以外の空白はDCC同じく読み飛ばす
    - 先頭で空白が初めて出た行はINDENTトークンを追加する
        - その空白の形式を以降のINDENTの認識に利用する
    - 空白が次の行でなくなった場合はDEDENTトークンを追加する